### PR TITLE
New frozen image. Improve publish workflows.

### DIFF
--- a/.github/workflows/publish-image-frozen.yml
+++ b/.github/workflows/publish-image-frozen.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
 
-          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
+          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect elrondnetwork/${{ github.event.inputs.image }} >/dev/null; then
               echo "Frozen image already published. Will NOT publish."
               exit 1
           else

--- a/.github/workflows/publish-image-frozen.yml
+++ b/.github/workflows/publish-image-frozen.yml
@@ -24,8 +24,11 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
     
+      # https://stackoverflow.com/questions/32113330/check-if-imagetag-combination-already-exists-on-docker-hub
       - name: Ensure image isn't already published
         run: |
+          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+
           if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
               echo "Frozen image already published. Will NOT publish."
               exit 1

--- a/.github/workflows/publish-image-frozen.yml
+++ b/.github/workflows/publish-image-frozen.yml
@@ -1,16 +1,15 @@
-name: Build & publish image
+name: Build & publish frozen image
 
 on:
   workflow_dispatch:
     inputs:
       image:
         type: choice
-        description: Image (with tag)
+        description: Frozen image (with tag)
         options: 
-        - elrond-sdk-erdpy:latest
-        - elrond-sdk-localnet:latest
-        - elrond-sdk-erdpy-rust:latest
-
+        - elrond-sdk-erdpy-rust:frozen-001
+        - elrond-sdk-erdpy-rust:frozen-002
+        
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
@@ -25,6 +24,15 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
     
+      - name: Ensure image isn't already published
+        run: |
+          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
+              echo "Frozen image already published. Will NOT publish."
+              exit 1
+          else
+              echo "Frozen image not yet published. Will publish."
+          fi
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/publish-image-frozen.yml
+++ b/.github/workflows/publish-image-frozen.yml
@@ -17,13 +17,7 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-    
+
       # https://stackoverflow.com/questions/32113330/check-if-imagetag-combination-already-exists-on-docker-hub
       - name: Ensure image isn't already published
         run: |
@@ -36,6 +30,12 @@ jobs:
               echo "Frozen image not yet published. Will publish."
           fi
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+  
       - name: Build and push Docker image
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -24,11 +24,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Ensure image isn't already published
+        run: |
+          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
+              echo "Frozen image already published. Will NOT publish."
+              exit 1
+          else
+              echo "Frozen image not yet published. Will publish."
+          fi
     
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          file: ./${{ github.event.inputs.image }}.dockerfile
-          tags: elrondnetwork/${{ github.event.inputs.image }}
+      # - name: Build and push Docker image
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     push: true
+      #     file: ./${{ github.event.inputs.image }}.dockerfile
+      #     tags: elrondnetwork/${{ github.event.inputs.image }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Ensure image isn't already published
         run: |
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
-          
-          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
+
+          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect elrondnetwork/${{ github.event.inputs.image }} >/dev/null; then
               echo "Frozen image already published. Will NOT publish."
               exit 1
           else

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Ensure image isn't already published
         run: |
+          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          
           if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect ${{ github.event.inputs.image }} >/dev/null; then
               echo "Frozen image already published. Will NOT publish."
               exit 1

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -24,22 +24,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Ensure image isn't already published
-        run: |
-          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
-
-          if DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect elrondnetwork/${{ github.event.inputs.image }} >/dev/null; then
-              echo "Frozen image already published. Will NOT publish."
-              exit 1
-          else
-              echo "Frozen image not yet published. Will publish."
-          fi
     
-      # - name: Build and push Docker image
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: .
-      #     push: true
-      #     file: ./${{ github.event.inputs.image }}.dockerfile
-      #     tags: elrondnetwork/${{ github.event.inputs.image }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          file: ./${{ github.event.inputs.image }}.dockerfile
+          tags: elrondnetwork/${{ github.event.inputs.image }}

--- a/elrond-sdk-erdpy-rust:frozen-002.dockerfile
+++ b/elrond-sdk-erdpy-rust:frozen-002.dockerfile
@@ -1,0 +1,37 @@
+# ===== FIRST STAGE ======
+FROM ubuntu:18.04 as builder
+
+RUN apt-get update && apt-get install wget -y
+RUN apt-get update && apt-get install python3.8 python3.8-venv python3-venv -y
+RUN groupadd -r elrond && useradd --no-log-init --uid 1001 -m -g elrond elrond
+USER elrond:elrond
+WORKDIR /home/elrond
+RUN wget -O erdpy-up.py https://raw.githubusercontent.com/ElrondNetwork/elrond-sdk-erdpy/master/erdpy-up.py
+RUN python3.8 ~/erdpy-up.py --exact-version=1.1.0
+ENV PATH="/home/elrond/elrondsdk:${PATH}"
+RUN erdpy deps install rust --tag="nightly-2022-03-01"
+RUN erdpy deps install nodejs --tag="v12.18.3"
+RUN erdpy deps install wasm-opt --tag="1.3.0"
+RUN rm -rf ~/elrondsdk/*.tar.gz
+RUN rm ~/erdpy-up.py
+
+# ===== SECOND STAGE ======
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install build-essential -y
+RUN apt-get update && apt-get install git -y
+RUN apt-get update && apt-get install python3.8 python3.8-venv python3-venv -y
+
+RUN groupadd -r elrond && useradd --no-log-init --uid 1001 -m -g elrond elrond
+USER elrond:elrond
+WORKDIR /home/elrond
+
+COPY --from=builder --chown=elrond:elrond /home/elrond/elrondsdk /home/elrond/elrondsdk
+ENV PATH="/home/elrond/elrondsdk:${PATH}"
+
+LABEL frozen="yes"
+LABEL erdpy="1.1.0"
+LABEL rust="nightly-2022-03-01"
+LABEL wasm-opt="v1.3.0"
+LABEL wasm-opt-binaryen="version_105"
+LABEL nodejs="v12.18.3"


### PR DESCRIPTION
 - New frozen image: `elrond-sdk-erdpy-rust:frozen-002`.
 - Split workflow into two: one for `frozen` images (never to be updated upon publishing on Docker Hub registry) and one for `latest` tags.

For reviewers: please check `elrond-sdk-erdpy-rust:frozen-002.dockerfile` by comparing it to `elrond-sdk-erdpy-rust:frozen-001.dockerfile`.

The configuration of `frozen-002` is the configuration used for:
 - https://github.com/ElrondNetwork/sc-dns-rs/releases/tag/v1.2.0
 - https://github.com/ElrondNetwork/sc-attestation-rs/releases/tag/v0.2.3